### PR TITLE
Add failing test for intersect + add / contains

### DIFF
--- a/tests/Set/intersect.php
+++ b/tests/Set/intersect.php
@@ -36,6 +36,30 @@ trait intersect
         $a = $this->getInstance($initial);
         $this->assertEquals($initial, $a->intersect($a)->toArray());
     }
+
+    public function testIntersectContains()
+    {
+        $setAB = $this->getInstance(["A", "B"]);
+        $setBC = $this->getInstance(["B", "C"]);
+
+        $setB = $setAB->intersect($setBC);
+
+        $this->assertFalse($setB->contains("A"));
+        $this->assertFalse($setB->contains("C"));
+        $this->assertTrue($setB->contains("B"));
+    }
+
+    public function testIntersectAdd()
+    {
+        $setAB = $this->getInstance(["A", "B"]);
+        $setBC = $this->getInstance(["B", "C"]);
+
+        $setB = $setAB->intersect($setBC);
+        $setB->add("B");
+
+        $this->assertEquals($setB->toArray(), ["B"]);
+    }
+
     // /**
     //  * @dataProvider intersectDataProvider
     //  */


### PR DESCRIPTION
**Note: This is specific to the extension. The polyfill does not have this problem.**

When two sets are intersected the resulting set:
- Breaks checking for items using contains. 
- Allows adding more than one identical item to the set.

Environment:
- PHP DS compiled from master as of this commit: https://github.com/php-ds/extension/commit/98bb0745c5210dacfee7e68fda12ab9522a448ba
- PHP 7.0.9
- macOS 10.11.6
