### PR TITLE
Add test case to union where it freezes PHP

### DIFF
--- a/tests/Set/union.php
+++ b/tests/Set/union.php
@@ -27,6 +27,18 @@ trait union
         $this->assertEquals($expected, $a->union($b)->toArray());
     }
 
+    /** @test */
+    public function testUnionDoesNotFreezeWhenOperatingOnSetsWithObjects()
+    {
+        $setA = $this->getInstance([new Box("X")]);
+        $setB = $this->getInstance([new Box("Y")]);
+
+        // PHP hangs when calling union on the above sets
+        $result = $setA->union($setB);
+
+        $this->assertTrue($result->toArray() === ["X", "Y"]);
+    }
+
     // /**
     //  * @dataProvider unionDataProvider
     //  */
@@ -78,4 +90,24 @@ trait union
     //     $a |= $a;
     //     $this->assertEquals($initial, $a->toArray());
     // }
+}
+
+class Box implements \Ds\Hashable
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function equals($obj) : bool
+    {
+        return $this->value === $obj->value;
+    }
+
+    public function hash()
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
I've got another interesting test for you. I've setup a minimal example where PHP completely freezes (or probably enters an infinite loop) when calling union on sets that contain `Hashable` objects.

I'm converting non-trivial I wrote that uses a custom set implementation to php-ds. Partly for fun and partly to see if I can get some performance increases. While doing so I am encountering small issues here and there.

I'll open PR's with tests with whatever I encounter if I find that the issue is appears to be w/in php-ds.

Environment:
- PHP DS re-compiled from master
- PHP 7.0.9
- macOS 10.11.6

Edit: I have also checked Ubuntu 14.04 and can reproduce it there as well.
