### PR TITLE
Fix expectPropertyDoesNotExistException test

### DIFF
--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -88,7 +88,8 @@ abstract class CollectionTest extends TestCase
 
     public function expectPropertyDoesNotExistException()
     {
-        $this->expectException(\OutOfBoundsException::class);
+        $this->expectException(\PHPUnit\Framework\Error\Notice::class);
+        $this->expectExceptionMessage('Undefined property');
     }
 
     public function expectReconstructionNotAllowedException()


### PR DESCRIPTION
**expectPropertyDoesNotExistException**

```php
$pair = new \Ds\Pair('a', 1);
$pair->x;
```

`PHP Notice:  Undefined property: Ds\Pair::$x`

