### PR TITLE
Don't sum non-numbers from PHP 8.3 onwards

### DIFF
--- a/tests/Map/sum.php
+++ b/tests/Map/sum.php
@@ -5,6 +5,7 @@ trait sum
 {
     public function sumDataProvider()
     {
+        $nonNumbers = version_compare(PHP_VERSION, '8.3.0', '>=') ? [true, false, null] : ["a", true, false, null];
         return [
 
             // Empty
@@ -23,7 +24,7 @@ trait sum
             [["2", "5", "10.5"], 17.5],
 
             // Non-numbers
-            [["a", true, false, null], 1],
+            [$nonNumbers, 1],
         ];
     }
 

--- a/tests/Sequence/sum.php
+++ b/tests/Sequence/sum.php
@@ -5,6 +5,7 @@ trait sum
 {
     public function sumDataProvider()
     {
+        $nonNumbers = version_compare(PHP_VERSION, '8.3.0', '>=') ? [true, false, null] : ["a", true, false, null];
         return [
 
             // Empty
@@ -23,7 +24,7 @@ trait sum
             [["2", "5", "10.5"], 17.5],
 
             // Non-numbers
-            [["a", true, false, null], 1],
+            [$nonNumbers, 1],
         ];
     }
 

--- a/tests/Set/sum.php
+++ b/tests/Set/sum.php
@@ -5,6 +5,7 @@ trait sum
 {
     public function sumDataProvider()
     {
+        $nonNumbers = version_compare(PHP_VERSION, '8.3.0', '>=') ? [true, false, null] : ["a", true, false, null];
         return [
 
             // Empty
@@ -23,7 +24,7 @@ trait sum
             [["2", "5", "10.5"], 17.5],
 
             // Non-numbers
-            [["a", true, false, null], 1],
+            [$nonNumbers, 1],
         ];
     }
 


### PR DESCRIPTION
As described in [polyfill issue 107](https://github.com/php-ds/polyfill/issues/107), array_sum behaviour changed in PHP 8.3.0 to raise an error for non-numbers. This PR removes non-numbers from testSum functions from 8.3.0 onwards to prevent those errors.